### PR TITLE
Add support to use custom icons classes

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -29,9 +29,15 @@ const App = () => {
       <SimpleEditable
         type="text"
         name="firstInput"
+        clearable
         value={firstInput}
         copyToClipboardEnabled
         onSave={setFirstInput}
+        iconsClassName={{
+          ok: 'fal fa-check',
+          cancel: 'fal fa-times',
+          copy: 'fal fa-copy'
+        }}
         errorComponent={(error) => {
           return (
             <div className="custom-error invalid-feedback" key="first-input-error">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-bootstrap-simple-editable",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A simple editable plugin with simple validations",
   "author": "8geonirt",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,8 @@ const SimpleEditable = ({
   hoverButtons,
   customComponent,
   clearable,
-  display
+  display,
+  iconsClassName
 }) => {
   const [editing, setEditing] = useState(false);
   const [currentValue, setCurrentValue] = useState(value);
@@ -134,7 +135,7 @@ const SimpleEditable = ({
           <div className={styles['editable-actions']}>
             { copyToClipboardEnabled &&
                 <span className={styles['editable-action__icon']} onClick={copyToClipboard}>
-                  <i className="fa fa-copy"></i>
+                  <i className={iconsClassName['copy']}></i>
                 </span>
             }
             { getHoverButtons() }
@@ -148,7 +149,7 @@ const SimpleEditable = ({
     return (
       <div>
         <button type="submit" className="btn">
-          <i className="fa fa-check"></i>
+          <i className={iconsClassName['ok']}></i>
         </button>
         <button
           type="button"
@@ -157,7 +158,7 @@ const SimpleEditable = ({
             clearError(['myInput']);
             setEditing(false);
           }}>
-          <i className="fa fa-times"></i>
+          <i className={iconsClassName['cancel']}></i>
         </button>
       </div>
     );
@@ -248,12 +249,18 @@ SimpleEditable.propTypes = {
   hoverButtons: PropTypes.func,
   customComponent: PropTypes.func,
   clearable: PropTypes.bool,
+  iconsClassName: PropTypes.object
 };
 
 SimpleEditable.defaultProps = {
   className: 'simple-editable',
   copyToClipboardEnabled: false,
-  clearable: false
+  clearable: false,
+  iconsClassName: {
+    ok: 'fa fa-check',
+    cancel: 'fa fa-times',
+    copy: 'fa fa-copy'
+  }
 }
 
 export default SimpleEditable;


### PR DESCRIPTION
- This commit creates a new defaultProp called iconsClassName, allowing
a developer to pass an object with the classes for the buttoms...
Initially this library was using the Font Awesome default icons, but it
is possible a developer is using Font Awesome Pro (to use light and
solid icons [fal, fas]).