### PR TITLE
Adds custom clipboard value

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -125,6 +125,11 @@ const App = () => {
           name="customComponent"
           value={{firstName, nickname, lastName}}
           copyToClipboardEnabled
+          clipboardValue={(values) => {
+            return (
+              <div key="custom-component-values">{values.nickname} {values.lastName}</div>
+            );
+          }}
           display={(values) => {
             return (
               <div key="custom-component-values"><b>{values.firstName}</b> {values.nickname} {values.lastName}</div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-bootstrap-simple-editable",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "A simple editable plugin with simple validations",
   "author": "8geonirt",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,8 @@ const SimpleEditable = ({
   clearable,
   display,
   iconsClassName,
-  copyMessage
+  copyMessage,
+  clipboardValue
 }) => {
   const [editing, setEditing] = useState(false);
   const [currentValue, setCurrentValue] = useState(value);
@@ -43,11 +44,18 @@ const SimpleEditable = ({
 
   const copyToClipboard = () => {
     const textField = document.createElement('input');
+    let valueToBeCopied = null;
+
     if (type === 'custom') {
-      textField.value = innerText(display(customValue));
+      if (clipboardValue) {
+        valueToBeCopied = clipboardValue(customValue)
+      } else {
+        valueToBeCopied = display(customValue);
+      }
     } else {
-      textField.value = innerText(currentValue);
+      valueToBeCopied = currentValue;
     }
+    textField.value = innerText(valueToBeCopied);
     document.body.appendChild(textField)
     textField.select();
     document.execCommand('copy');
@@ -240,7 +248,8 @@ SimpleEditable.propTypes = {
   hoverButtons: PropTypes.func,
   customComponent: PropTypes.func,
   clearable: PropTypes.bool,
-  iconsClassName: PropTypes.object
+  iconsClassName: PropTypes.object,
+  clipboardValue: PropTypes.func
 };
 
 SimpleEditable.defaultProps = {


### PR DESCRIPTION
- This commits adds a new prop that allows to pass a custom value to be
copied to the clipboard... There are some cases when a custom component
is used and we don't want to have all of the children copied to the
clipboard.

Example: a custom component that renders the following display...

<b>Phone</b> <span>+5211111111</span>
Phone is being display as a result of a dropdown, but only the number
should be copied to the clipboard.

To achieve that we could pass the clipboardValue prop as:
```
clipboardValue={(values) => {
  return (
    <div key="custom-component-values">{values.nickname} {values.lastName}</div>
  );
}}
```

The value of the select is not rendered in there.